### PR TITLE
feat: Implement users typing functionality

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -68,6 +68,16 @@ type Message {
   updatedAt: Timestamp!
 }
 
+type UserTypingIndicatorChanged {
+  _id: String!
+  name: String!
+}
+
+type TypingIndicatorChanged {
+  user: UserTypingIndicatorChanged!
+  isTyping: Boolean!
+}
+
 type RoomUser {
   _id: String!
   roomId: ID!
@@ -110,6 +120,7 @@ type Mutation {
   verifyEmail(data: EmailVerificationInput!): EmailVerifyResponse!
   createMessage(data: MessageCreateInput!): Message!
   updateMessage(data: MessageUpdateInput!, id: ID!): Message!
+  changeTypingIndicator(isTyping: Boolean!, roomId: ID!): Boolean!
   createRoom(data: RoomCreateInput!): Room!
   updateRoom(data: RoomUpdateInput!, _id: ID!): Room!
   createRoomUser(data: RoomUserCreateInput!): RoomUser!
@@ -202,4 +213,5 @@ input WordUpdateInput {
 
 type Subscription {
   messageCreated(roomId: String!): Message!
+  typingIndicatorChanged(roomId: ID!): TypingIndicatorChanged!
 }

--- a/src/decorators/currentUser.decorator.ts
+++ b/src/decorators/currentUser.decorator.ts
@@ -1,7 +1,9 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common'
 import { GqlExecutionContext } from '@nestjs/graphql'
 
-export const CurrentUser = createParamDecorator((data: unknown, context: ExecutionContext) => {
-  const ctx = GqlExecutionContext.create(context)
-  return ctx.getContext().req.user
+export const CurrentUser = createParamDecorator((field: string, context: ExecutionContext) => {
+  const gqlContext = GqlExecutionContext.create(context).getContext()
+  const user = gqlContext?.req.user
+
+  return field ? user && user[field] : user
 })

--- a/src/modules/messages/dto/typing-indicator-changed.ts
+++ b/src/modules/messages/dto/typing-indicator-changed.ts
@@ -1,0 +1,19 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+
+@ObjectType()
+class UserTypingIndicatorChanged {
+  @Field()
+  _id: string
+
+  @Field()
+  name: string
+}
+
+@ObjectType()
+export class TypingIndicatorChanged {
+  @Field(type => UserTypingIndicatorChanged)
+  user: UserTypingIndicatorChanged
+
+  @Field()
+  isTyping: boolean
+}


### PR DESCRIPTION
Close #34  

* Add users typing functionality with subscriptions
* Improve `CurrentUser` decorator

### Not covered
* Persistence for users typing is not yet implemented, will be added in future versions

### Cons of No persistence in BE
* If users get offline and not dispatch the `stopTyping`, the other users always see these user are typing.
* If users have multiple clients connected to the socket, events are overwritten. Fix that problem in FE adds more complexity and I think is better to apply that effort in BE and get a better system.